### PR TITLE
Add prototype cell in IB for cell reuse (dequeReusableCellWithIdentifier) in cellForRowAtIndexPath

### DIFF
--- a/GeneratedResults/Base.lproj/Main.storyboard
+++ b/GeneratedResults/Base.lproj/Main.storyboard
@@ -20,6 +20,25 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="gqx-vR-SoX">
                                 <rect key="frame" x="0.0" y="20" width="600" height="580"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="35g-MQ-aoa" style="IBUITableViewCellStyleDefault" id="kYY-ku-D0r">
+                                        <rect key="frame" x="0.0" y="22" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kYY-ku-D0r" id="k6D-ww-VlZ">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="35g-MQ-aoa">
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
                                 <connections>
                                     <outlet property="dataSource" destination="vXZ-lx-hvc" id="XMe-Wg-Xb0"/>
                                     <outlet property="delegate" destination="vXZ-lx-hvc" id="VQd-7d-Ppv"/>

--- a/GeneratedResults/ViewController.swift
+++ b/GeneratedResults/ViewController.swift
@@ -72,7 +72,7 @@ extension ViewController: UITableViewDataSource {
     }
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: nil)
+        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath)
         let contact = contacts[indexPath.row]
         cell.textLabel?.text = "\(contact.firstName) \(contact.lastName)"
         return cell


### PR DESCRIPTION
Added a prototype table view cell from the storyboard with the identifier "Cell". Instead of creating a brand new table view cell instance in `cellForRowAtIndexPath` every time a cell row is required, this change calls `dequeReusableCellWithIdentifier` to allow the tableview to manage the reuse of cells. 
